### PR TITLE
updated yellow modifier link colour

### DIFF
--- a/src/wmnds/components/content-tiles/normal/_normal.scss
+++ b/src/wmnds/components/content-tiles/normal/_normal.scss
@@ -43,5 +43,9 @@
   // Yellow modifier
   &--yellow {
     background-color: get-color(plannedDisruption);
+
+    .wmnds-link {
+      color: get-color(text);
+    }
   }
 }


### PR DESCRIPTION
- Updated read more link to text colour to fix contrast issue (as per sketch file):

<img width="487" alt="Screenshot 2020-08-19 at 10 26 19" src="https://user-images.githubusercontent.com/6360479/90617303-6deab180-e206-11ea-989f-ca0b359e96c6.png">

fixes #274 