### PR TITLE
add explicit margin: 0 to top lvl nav items

### DIFF
--- a/src/wmnds/patterns/header-v2/_header-v2.scss
+++ b/src/wmnds/patterns/header-v2/_header-v2.scss
@@ -549,6 +549,7 @@ $header-height-mobile: 4rem;
 
     &__primary-menu-link {
       min-height: 100%;
+      margin: 0;
       padding: 1rem 1.5rem;
       transition: $link-transition;
       color: $white;


### PR DESCRIPTION
Prevent safari adding margin to top level navigation buttons fixes #461 