### PR TITLE
Amended grid/column size

### DIFF
--- a/src/wmnds/assets/sass/_utilities.scss
+++ b/src/wmnds/assets/sass/_utilities.scss
@@ -24,11 +24,11 @@
 // Container sizes
 .wmnds-container {
   display: block;
-  max-width: $breakpoint-xl;
+  max-width: $breakpoint-lg;
   margin: auto;
   padding: 0 $size-sm;
 
-  @media screen and (min-width: $breakpoint-md) {
+  @media screen and (min-width: $breakpoint-lg) {
     padding: 0 $size-md;
   }
 

--- a/src/wmnds/assets/sass/_vars.scss
+++ b/src/wmnds/assets/sass/_vars.scss
@@ -68,15 +68,15 @@ $size-xl: 3rem; // 48px
 $breakpoint-xs: 0; // Extra small screen / phone
 $breakpoint-sm: 568px; // Small screen / phone
 $breakpoint-md: 768px; // Medium screen / tablet
-$breakpoint-lg: 1024px; // Large screen / desktop
-$breakpoint-xl: 1280px; // Extra large screen / wide desktop (this is used for wmnds-container size)
+$breakpoint-lg: 992px; // Large screen / desktop (this is used for wmnds-container size)
+$breakpoint-xl: 1280px; // Extra large screen / wide desktop
 
 // Grid vars
 $cols: 1 2 3 4 5 6 12 24;
 $grid-breakpoint-map: (
   "sm": 35.5,
   "md": 48,
-  "lg": 64,
+  "lg": 62,
   "xl": 80
 );
 $grid-max-cols: 5;

--- a/src/wmnds/assets/sass/wmnds-grid/_grid-cols.scss
+++ b/src/wmnds/assets/sass/wmnds-grid/_grid-cols.scss
@@ -597,7 +597,7 @@ textarea,
   }
 }
 
-@media screen and (min-width: 64em) {
+@media screen and (min-width: 62em) {
   .wmnds-col-lg-auto,
   .wmnds-col-lg-1,
   .wmnds-col-lg-1-1,

--- a/src/www/_layouts/layout-left-pane.njk
+++ b/src/www/_layouts/layout-left-pane.njk
@@ -1,11 +1,11 @@
 {% extends "www/_layouts/_master-layout.njk" %}
 
 {% block body %}
-<div class="wmnds-grid">
-  <div class="wmnds-col-1 wmnds-col-md-1-4">
+<div class="wmnds-grid wmnds-grid--spacing-lg-2-lg">
+  <div class="wmnds-col-1 wmnds-col-lg-1-3 wmnds-p-b-lg">
     {% include "www/_partials/nav/subnav.njk" %}
   </div>
-  <div class="wmnds-col-1 wmnds-col-md-3-4" id="wmnds-main-content">
+  <div class="wmnds-col-1 wmnds-col-lg-2-3" id="wmnds-main-content">
     <h1>{{ pageTitle }}</h1>
     <hr>
     {% block content %}{% endblock content %}

--- a/src/www/pages/index.njk
+++ b/src/www/pages/index.njk
@@ -9,10 +9,9 @@
 
 
 {% block content %}
-<div class="wmnds-grid wmnds-grid--align-center">
+<div class="wmnds-grid wmnds-grid--align-center wmnds-grid--spacing-lg-2-xl">
   {# Overview #}
-  <div class="wmnds-col-1 wmnds-col-xl-3-4">
-    <div class="wmnds-col-md-3-4">
+  <div class="wmnds-col-1 wmnds-col-lg-2-3">
       <h2>Overview</h2>
       <p>
         The West Midlands Network (WMN) Design System is a library of typography, visual styles and user interface components which are documented and updated continuously.
@@ -23,10 +22,9 @@
       <p>
         Our design system aims to be platform/framework agnostic. This allows designers and developers from all practices to utilise our design system and avoid repeating work that's already been done.
       </p>
-    </div>
   </div>
   {# Design system links #}
-  <div class="wmnds-col-1 wmnds-col-xl-1-4">
+  <div class="wmnds-col-1 wmnds-col-lg-1-3">
     <h2>Contribute</h2>
     {# Github code repo #}
     <p>

--- a/src/www/pages/styles/utility-classes/index.njk
+++ b/src/www/pages/styles/utility-classes/index.njk
@@ -64,7 +64,7 @@
     <li>Extra Small Devices (≥320px, 2-col + 1-col)</li>
     <li>Small Device 2 (SM) (≥568px 6-col + 3-col + 2-col)</li>
     <li>Small Device (MD) (≥768px)</li>
-    <li>Medium Device (LG) (≥1024px)</li>
+    <li>Medium Device (LG) (≥992px)</li>
     <li>Large Device (XL) (≥1280px)</li>
   </ul>
 </p>
@@ -72,7 +72,7 @@
 <p>
   <ul>
     <li><strong>1280px</strong>: 12 columns, 960px total width, 80px each which includes 16px padding and 64px content area column</li>
-    <li><strong>1024px</strong>: 12 columns, 768px total width, 64px each which includes 16px padding and 48px content area column</li>
+    <li><strong>992px</strong>: 12 columns, 960px total width, 80px each which includes 16px padding and 64px content area column</li>
     <li><strong>768px</strong>: 12 columns, 576px width, 48px each which includes 16px padding and 32px content area column</li>
     <li><strong>568px</strong>: 6 columns, 426px width, 71px each which includes 16px padding and 55px content area column</li>
     <li><strong>568px</strong>: 3 columns, 426px width, 142px each which includes 16px padding and 126px content area column</li>


### PR DESCRIPTION
Fixes #470 

- Changes $breakpoint-lg from 1024px to 992px to force max width of 960px on grid container
- Added gutters and changed left pane layout to 1/3 - 2/3 column widths