### PR TITLE
fix responsive grid bug

### DIFF
--- a/src/wmnds/assets/sass/_utilities.scss
+++ b/src/wmnds/assets/sass/_utilities.scss
@@ -32,6 +32,7 @@
 // Container sizes
 .wmnds-container {
   display: block;
+  width: 100%;
   max-width: $breakpoint-lg;
   margin: auto;
   padding: 0 $size-sm;


### PR DESCRIPTION
Simple fix for responsive bug below where wmnds-container doesn't shrink past max-width
<img width="583" alt="Screenshot 2020-11-04 at 09 12 22" src="https://user-images.githubusercontent.com/6360479/98091965-098ed400-1e7e-11eb-9af1-db756ba0b0f3.png">
