### PR TITLE
fix: Updated version number to development

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wmn-design-system",
-  "version": "1.1.0",
+  "version": "0.0.0-development",
   "description": "A library of typography, visual styles and user interface components which are documented for West Midlands Network.",
   "homepage": "https://designsystem.wmnetwork.co.uk",
   "author": "WMCA",


### PR DESCRIPTION
Updated the version number to 0.0.0-development as this automatically gets updated on the build for live so we don't care for it in development.