### PR TITLE
fix: bug when creating ordered list with headers classes

### DIFF
--- a/src/wmnds/assets/sass/styles/_lists.scss
+++ b/src/wmnds/assets/sass/styles/_lists.scss
@@ -36,13 +36,14 @@
       counter-increment: item;
     }
   }
-
+  
 
   // Create correct spacing for indent allowing for increase in counter length
   $selector: "ol:not([class*='wmnds-']) li";
   @for $i from 0 through 5 {
     #{repeater($selector, $i, " > ")}:before {
-      left: -#{1.25 + (($i + 1) * 0.8rem)};
+      left: -#{1.5 + (($i + 1) * 0.8rem)};
+      width: calc(-#{1.5 + (($i + 1) * 0.8rem)} - 0.25rem);
     }
   }
 }

--- a/src/wmnds/assets/sass/styles/_lists.scss
+++ b/src/wmnds/assets/sass/styles/_lists.scss
@@ -29,10 +29,14 @@
     &:before {
       content: counters(item, ".") ".";
       position: absolute;
-      left: -1.5rem;
+      left: -3rem;
+      width: 2.75rem;
+      padding-right: 0.25rem;
+      text-align: right;
       counter-increment: item;
     }
   }
+
 
   // Create correct spacing for indent allowing for increase in counter length
   $selector: "ol:not([class*='wmnds-']) li";

--- a/src/wmnds/assets/sass/styles/_typography.scss
+++ b/src/wmnds/assets/sass/styles/_typography.scss
@@ -83,6 +83,14 @@ h6,
   font-weight: normal;
 }
 
+.h2 > *,
+.h3 > *,
+.h4 > *,
+.h5 > * {
+  color: initial;
+  font-weight: initial;
+}
+
 p,
 ul,
 ol,

--- a/src/wmnds/assets/sass/styles/_typography.scss
+++ b/src/wmnds/assets/sass/styles/_typography.scss
@@ -52,6 +52,7 @@ h2,
 .h2 {
   color: get-color(primary);
   @include type-setting(2, 0.85);
+  font-weight: bold;
   // On desktop devices
   @media all and (min-width: $breakpoint-md) {
     @include type-setting(2);
@@ -61,16 +62,19 @@ h2,
 h3,
 .h3 {
   @include type-setting(3);
+  font-weight: bold;
 }
 
 h4,
 .h4 {
   @include type-setting(4);
+  font-weight: bold;
 }
 
 h5,
 .h5 {
   @include type-setting(5);
+  font-weight: bold;
 }
 
 h6,

--- a/src/www/pages/styles/lists/index.njk.md
+++ b/src/www/pages/styles/lists/index.njk.md
@@ -39,6 +39,30 @@
 {{
   compExample([
     "<ol class='wmnds-ordered-list'>
+        <li class='h2'>Level 2
+          <ol>
+            <li class='h3'>Level 3
+              <ol>
+                <li class='h4'>Level 4</li>
+                <li class='h4'>Level 4
+                  <ol>
+                    <li class='h5'>Level 5
+                      <ol>
+                        <li>Text</li>
+                      </ol>
+                  </li>
+                  </ol>
+                </li>
+                <li class='h4'>Level 4</li>
+              </ol>
+            </li>
+            <li class='h3'>Level 3</li>
+          </ol>
+      </li>
+      <li class='h2'>Level 2</li>
+    </ol>
+    <br/><br/>
+    <ol class='wmnds-ordered-list'>
         <li>Text
           <ol>
             <li>Text
@@ -56,7 +80,8 @@
           </ol>
       </li>
       <li>Text</li>
-    </ol>"
+    </ol>
+    "
   ])
 }}
 {% markdown %}


### PR DESCRIPTION
- Add font-weight to header classes and prevent style inheritance when using header classes.
- Allow bigger numbers (adding a padding-right, aligning the text to the right and increment the size of it)

Fixes part of [https://github.com/wmcadigital/wmn-cms/issues/50](https://github.com/wmcadigital/wmn-cms/issues/50)