### PR TITLE
fix: Updates to dependabot and branch guard config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: monthly
-    open-pull-requests-limit: 10
-    commit-message:
-      prefix: '[skip netlify]'
+      interval: daily
+    open-pull-requests-limit: 0
+    target-branch: 'develop'

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -11,10 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        if: "!(startsWith(github.head_ref, 'release'))"
+        if: "github.base = 'main' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
-          echo "head branch is: $GITHUB_HEAD_REF"
+          echo "head branch is: $GITHUB_HEAD_REF";
+          echo "base branch is: $GITHUB_BASE_REF";
           echo "*****";
           echo "::error::Only release branch is allowed to merge to master";
           exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -9,13 +9,13 @@ on:
 jobs:
   can-merge-to-branch:
     name: Can merge to branch
+    if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Allowed to merge to master
-        if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
+      - name: Checking if branch is allowed...
         run: |
           echo "";
-          echo "*****";
-          echo "::error::Not allowed to merge $GITHUB_HEAD_REF branch into $GITHUB_BASE_REF branch";
+          echo "::error::Not allowed to merge '$GITHUB_HEAD_REF' branch into '$GITHUB_BASE_REF' branch";
+          echo "---";
           exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -5,6 +5,7 @@ name: 'Branch guard'
 
 on:
   pull_request:
+    types: [opened, edited, synchronize]
 
 jobs:
   can-merge-to-branch:

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "::error::**Only release is allowed to merge to master**"; exit 1;
+        run: |
+          echo "::error::
+            *****
+            Only release branch is allowed to merge to master";
+            exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,5 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "\033[0;31mOnly release is allowed to merge to master"; exit 1;
+        run: echo "\n\n \033[0;31mOnly release is allowed to merge to master"; exit 1;
+        # \n = new line
         # \033[0;31m = red text

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: { echo "Only release is allowed to merge to master"; exit 1' }
+        run: echo "Only release is allowed to merge to master"; exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        if: "github.base = 'main' && !(startsWith(github.head_ref, 'release'))"
+        if: "github.base == 'main' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
           echo "head branch is: $GITHUB_HEAD_REF";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,6 +14,7 @@ jobs:
         if: "!(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
+          echo "head branch is: $GITHUB_HEAD_REF"
           echo "*****";
           echo "::error::Only release branch is allowed to merge to master";
           exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "::error:: **Only release is allowed to merge to master**"; exit 1;
+        run: echo "::error::**Only release is allowed to merge to master**"; exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "Only release is allowed to merge to master"; exit 1;
+        run: echo "::error **Only release is allowed to merge to master**"; exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Checking if branch is allowed...
-        if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
+        if: "github.base_ref == 'master' && github.head_ref != 'release'"
         run: |
           echo "";
           echo "::error::Not allowed to merge '$GITHUB_HEAD_REF' branch into '$GITHUB_BASE_REF' branch";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        if: "github.base == 'main' && !(startsWith(github.head_ref, 'release'))"
+        if: "github.base_ref == 'main' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
           echo "head branch is: $GITHUB_HEAD_REF";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -1,0 +1,17 @@
+name: 'Prevent PR to master unless release'
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened, edited, synchronize]
+
+jobs:
+  check-if-bad-PR:
+    name: Checking if bad PR to master
+    if: "!(startsWith(github.head_ref, 'master'))"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Try to fail
+        run: exit 1

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "Only release is allowed to merge to master" | exit 1
+        run: { echo "Only release is allowed to merge to master"; exit 1' }

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -2,8 +2,6 @@ name: 'Branch guard'
 
 on:
   pull_request:
-    branches:
-      - master
     types: [opened, edited, synchronize]
 
 jobs:

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -1,4 +1,4 @@
-name: 'Prevent PR to master unless release'
+name: 'Branch guard'
 
 on:
   pull_request:
@@ -7,11 +7,12 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
-  check-if-bad-PR:
-    name: Checking if bad PR to master
+  allowed-to-merge-to-master:
+    name: Check if allowed to merge to master
     if: "!(startsWith(github.head_ref, 'master'))"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Try to fail
+      - name: Allowed to merge to master
+        run: echo "Only release is allowed to merge to master"
         run: exit 1

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -2,7 +2,6 @@ name: 'Branch guard'
 
 on:
   pull_request:
-    types: [opened, edited, synchronize]
 
 jobs:
   can-merge-to-branch:
@@ -11,11 +10,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
+        # if the base_ref(target branch we want to merge to) is master and the head_ref(source branch we want to merge from)
+        # Then throw an error, as only release is allowed to merge into master
+        # Otherwise this action won't run and show as success
         if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
-          echo "head branch is: $GITHUB_HEAD_REF";
-          echo "base branch is: $GITHUB_BASE_REF";
           echo "*****";
-          echo "::error::Only release branch is allowed to merge to master";
+          echo "::error::Not allowed to merge $GITHUB_HEAD_REF branch into $GITHUB_BASE_REF branch";
           exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,6 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "\n\n \033[0;31mOnly release is allowed to merge to master"; exit 1;
-        # \n = new line
-        # \033[0;31m = red text
+        run: echo "Only release is allowed to merge to master"; exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   allowed-to-merge-to-master:
     name: Check if allowed to merge to master
-    if: "!(startsWith(github.head_ref, 'master'))"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
+        if: "!(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
           echo "*****";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,5 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "Only release is allowed to merge to master"
-        run: exit 1
+        run: echo "Only release is allowed to merge to master" | exit 1

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   can-merge-to-branch:
     name: Can merge to branch
-    if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Checking if branch is allowed...
+        if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
           echo "::error::Not allowed to merge '$GITHUB_HEAD_REF' branch into '$GITHUB_BASE_REF' branch";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "::error **Only release is allowed to merge to master**"; exit 1;
+        run: echo "::error:: **Only release is allowed to merge to master**"; exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
         run: |
-          echo "::error::
-            *****
-            Only release branch is allowed to merge to master";
-            exit 1;
+          echo "";
+          echo "*****";
+          echo"::error::Only release branch is allowed to merge to master";
+          exit 1;

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -1,3 +1,6 @@
+# if the base_ref(target branch we want to merge to) is master and the head_ref(source branch we want to merge from)
+# Then throw an error, as only release is allowed to merge into master
+# Otherwise this action won't run and show as success
 name: 'Branch guard'
 
 on:
@@ -10,9 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        # if the base_ref(target branch we want to merge to) is master and the head_ref(source branch we want to merge from)
-        # Then throw an error, as only release is allowed to merge into master
-        # Otherwise this action won't run and show as success
         if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -12,7 +12,7 @@ jobs:
     name: Can merge to branch
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Checking if branch is allowed...
         if: "github.base_ref == 'master' && github.head_ref != 'release'"
         run: |

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -5,8 +5,8 @@ on:
     types: [opened, edited, synchronize]
 
 jobs:
-  allowed-to-merge-to-master:
-    name: Check if allowed to merge to master
+  can-merge-to-branch:
+    name: Can merge to branch
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        if: "github.base_ref == 'main' && !(startsWith(github.head_ref, 'release'))"
+        if: "github.base_ref == 'master' && !(startsWith(github.head_ref, 'release'))"
         run: |
           echo "";
           echo "head branch is: $GITHUB_HEAD_REF";

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -14,4 +14,5 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Allowed to merge to master
-        run: echo "Only release is allowed to merge to master"; exit 1;
+        run: echo "\033[0;31mOnly release is allowed to merge to master"; exit 1;
+        # \033[0;31m = red text

--- a/.github/workflows/prevent-pr-master.yml
+++ b/.github/workflows/prevent-pr-master.yml
@@ -17,5 +17,5 @@ jobs:
         run: |
           echo "";
           echo "*****";
-          echo"::error::Only release branch is allowed to merge to master";
+          echo "::error::Only release branch is allowed to merge to master";
           exit 1;


### PR DESCRIPTION
Update the dependabot config so it is turned off, but we should get notifications about security alerts.
Also added a new github action (branch guard) which will fail if you try to open a PR onto master and you are not the release branch.