### PR TITLE
fix: Updated Content-Type for CSS files when being redirected.

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,4 @@
 # domain redirects
-
+https://westmidlands.network/* https://designsystem.wmnetwork.co.uk/:splat 301!
+https://wmnetwork.netlify.app/* https://designsystem.wmnetwork.co.uk/:splat 301!
 /docs /docs/get-started/ 301!

--- a/_redirects
+++ b/_redirects
@@ -1,5 +1,4 @@
 # domain redirects
 https://westmidlands.network/* https://designsystem.wmnetwork.co.uk/:splat 301!
 https://wmnetwork.netlify.app/* https://designsystem.wmnetwork.co.uk/:splat 301!
-https://deploy-preview-758--wmnetwork.netlify.app/* https://designsystem.wmnetwork.co.uk/:splat 301!
 /docs /docs/get-started/ 301!

--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,3 @@
 # domain redirects
-https://westmidlands.network/* https://designsystem.wmnetwork.co.uk/:splat 301!
-https://wmnetwork.netlify.app/* https://designsystem.wmnetwork.co.uk/:splat 301!
+
 /docs /docs/get-started/ 301!

--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,5 @@
 # domain redirects
 https://westmidlands.network/* https://designsystem.wmnetwork.co.uk/:splat 301!
 https://wmnetwork.netlify.app/* https://designsystem.wmnetwork.co.uk/:splat 301!
+https://deploy-preview-758--wmnetwork.netlify.app/* https://designsystem.wmnetwork.co.uk/:splat 301!
 /docs /docs/get-started/ 301!

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,11 @@
     [headers.values]
       Access-Control-Allow-Origin = "*"
 
+[[headers]]
+  for = '/*.css'
+    [headers.values]
+      Content-Type = "text/css"
+
 # Generate sitemap
 [[plugins]]
 package = "@netlify/plugin-sitemap"


### PR DESCRIPTION
This issue will resolve an issue where third-party services are utilising our design system CSS directly.
Currently it causes a warning of incorrect MIME-TYPE, due to the redirects it transforms the MIME-TYPE to text/plain or text/HTML as it goes through the redirects. When it should be text/css as it is a CSS file.

**An example of how the redirects and MIME-TYPES change...**
wmnetwork.netlify.com/wmnds-components.min.css (text/html) -> 
wmnetwork.netlify.app/wmnds-components.min.css (text/plain) -> 
designsystem.wmnetwork.co.uk/wmnds-components.min.css (text/css)

This update ensures that the MIME stays as text/css throughout the redirect process which will remove the warning shown in the console tab. I have a feeling this issue may have a side-effect of some browsers blocking the css as the MIME keeps changing so can be seen as unsafe.