### PR TITLE
fix: Updated transport banner font color to white for all html tags

### DIFF
--- a/src/wmnds/patterns/travel-mode-page-banner/_travel-mode-page-banner.scss
+++ b/src/wmnds/patterns/travel-mode-page-banner/_travel-mode-page-banner.scss
@@ -64,12 +64,12 @@
     }
   }
 
-  h2 {
-    color: currentColor;
-  }
-
   &__copy {
     max-width: 100%;
+
+    & > * {
+      color: $white;
+    }
   }
 
   &__logos {
@@ -77,7 +77,7 @@
 
     svg {
       width: 3rem;
-      fill: currentColor;
+      fill: $white;
     }
 
     svg,


### PR DESCRIPTION
Allow all html tags within 'copy' class of travel banner to have the colour of white.
Currently this is limited to just h2 tags.

This will help resolve:  https://github.com/wmcadigital/wmn-cms/issues/103