### PR TITLE
fix: Updated CSS, long route names display correctly in travel updates widget

### DIFF
--- a/src/wmnds/patterns/travel-updates/_travel-updates.scss
+++ b/src/wmnds/patterns/travel-updates/_travel-updates.scss
@@ -70,11 +70,12 @@
       }
 
       .wmnds-travel-update__disruption-indicator-btn {
-        display: inline-block;
+        display: inline-flex;
         margin-right: $size-md;
         padding: 0;
         border: 0;
         background: none;
+        flex-direction: column;
 
         .wmnds-disruption-indicator-medium {
           margin: 0;
@@ -82,7 +83,10 @@
       }
 
       .wmnds-travel-update__disruption-text {
+        display: inline-flex;
         text-align: left;
+        flex-direction: column;
+        flex: 1;
 
         strong {
           display: block;


### PR DESCRIPTION
This minor change fixes an issue where long route names would make the travel indicators appear above the names when they should appear side by side in desktop view. 

An example of the bug can be seen:

![image](https://user-images.githubusercontent.com/13015201/123650608-a396f880-d822-11eb-8e41-cce38a03a892.png)
