### PR TITLE
fix: increase z-index on header

### DIFF
--- a/src/wmnds/patterns/header-v2/_header-v2.scss
+++ b/src/wmnds/patterns/header-v2/_header-v2.scss
@@ -476,7 +476,7 @@ $header-height-mobile: 4rem;
 // mega menu header modifier
 &.wmnds-header--mega-menu {
   position: relative;
-  z-index: 1000;
+  z-index: 15000;
   padding: 0;
 
   @media screen and (max-width: $breakpoint-md - 1) {


### PR DESCRIPTION
Increased z-index on mega menu header to prevent body elements overlapping when menu is open.

fixes #880 